### PR TITLE
Allow suggestions to take and return objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ check the [index.ios.js](https://github.com/silesky/AutosuggestExample/blob/mast
 
 ```
 
+### Complex suggestions example:
+
+You can also use a more complex set of 'term' items (taking the shape: `{ term: string, searchableID?: string, value?: any }`) allowing for search by a hidden ID, but also allowing the return of objects, etc rather than simply strings.
+
+In the below example, we can take a list of fruits, some are just strings, the rest are objects, some with values, others with searchable ID values.
+
+```js
+   <AutoSuggest
+      onChangeText={(fruit) => this.setState({fruit:null})}
+      onItemPress={(fruit) => this.setState({fruit:fruit.value||fruit.term||fruit})}
+      formatString={({term, searchableID}) => `${searchableID} | ${term}`}
+      terms={[{term:'Apple', searchableID:'100'}, {term:'Banana', searchableID:'101'}, {term:'Orange', searchableID:'102'}, {term:'Strawberry', value:{name:'Strawberry', bestFruit:true}}, 'Lemon', 'Cantaloupe', 'Peach', 'Mandarin', 'Date', 'Kiwi']}
+    />
+
+```
+As props, we use `onItemPress` to detect selection of an item so we can write the value of the item to state, and `onChangeText` to listen for a user typing, which in this case removes any selected item. `formatString` is only used when searching by ID, otherwise `term` is used. In this case, it is used to display `100 | Apple`, if a user were to type `100`, however the value it returns `onItemPress` will just be `Apple`.
+
 
 ## Props
 
@@ -31,7 +48,7 @@ check the [index.ios.js](https://github.com/silesky/AutosuggestExample/blob/mast
 | `onChangeText`          | Function | false  |  (prop is manadatory)  |  fired when the input changes. e.g (ev) => console.log(event)
 | `terms`                 | Array    | false  |  (prop is mandatory)   |  list of suggestions. e.g ['Chicago', 'New York', 'San Francisco'] |
 | `onChangeTextDebounce` | Number   |  true |  300 |  the minimum break *in milliseconds* that the onChangeText callback needs to take before firing again.   |
-| `onItemPress` | Function | true |  undefined | fired when an item in the menu is pressed with that item's string value as the argument. You probably don't need this, and should just use onChangeText
+| `onItemPress` | Function | true |  undefined | fired when an item in the menu is pressed with that item's string value as the argument. This is useful for dealing with terms as objects, otherwise you should just use onChangeText
 | `placeholder` | String | true | '' | e.g 'please enter a name' |
 | `clearBtnStyles` | Object | true | ...see src | styles that go around your clear btn |
 | `clearBtnVisibility` | Bool | true | false | is the clear input button visible? |
@@ -42,3 +59,4 @@ check the [index.ios.js](https://github.com/silesky/AutosuggestExample/blob/mast
 | `textInputStyles` | Object | true | undefined | applies to the TextInput component e.g {width: 400, backgroundColor: "black"})
 | `rowWrapperStyles` | Object | true | undefined | applies to the View around the dropdown |
 | `rowTextStyles` | Object | true | undefined | applies the dropdown text
+| `formatString` | Function | true | undefined | a function that outputs a string which takes a term object to format an item found using its `searchableID`

--- a/src/AutoSuggest.js
+++ b/src/AutoSuggest.js
@@ -15,9 +15,6 @@ import debounce from '../vendor/throttle-debounce/debounce'
 import { version } from 'react-native/package.json'
 const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 })
 
-// 'term' objects take the shape
-//   { term: string, searchableID?: string (TODO, allow int), value?: any, formatString?: function }
-
 export default class AutoSuggest extends Component {
   static propTypes = {
     containerStyles: PropTypes.object,

--- a/src/AutoSuggest.js
+++ b/src/AutoSuggest.js
@@ -186,7 +186,10 @@ export default class AutoSuggest extends Component {
             }
          </View>
          <View>
-            <ListView style={{position: 'absolute', width: this.state.TIWidth, backgroundColor: 'white', zIndex: 3}}
+            <ListView style={{
+                position: 'absolute', width: this.state.TIWidth, backgroundColor: 'white', zIndex: 3,
+                borderBottomLeftRadius: 4, borderBottomRightRadius: 4, borderColor:"#cccccc", borderWidth: this.state.results.length>0 ? 1 : 0
+              }}
               keyboardShouldPersistTaps={version >= '0.4.0' ? 'always' : true}
               initialListSize={15}
               enableEmptySections

--- a/src/AutoSuggest.js
+++ b/src/AutoSuggest.js
@@ -119,7 +119,7 @@ export default class AutoSuggest extends Component {
       const results = this.props.terms.filter(eachTerm => {
         if (typeof eachTerm === 'object')  {
           if (eachTerm.term && findMatch(eachTerm.term, currentInput)) return eachTerm
-          if (eachTerm.searchableID && findMatch(eachTerm.searchableID, currentInput)) return eachTerm
+          if (eachTerm.searchableID && findMatch(eachTerm.searchableID, currentInput)) {eachTerm.foundByID=true; return eachTerm }
         }
         else if (findMatch(eachTerm, currentInput)) return eachTerm
       })
@@ -144,7 +144,7 @@ export default class AutoSuggest extends Component {
     }
     return styleObj
   }
-  termString = term => ( typeof term === 'string' ? term : (this.props.formatString?this.props.formatString(term):term.term) )
+  termString = term => (typeof term === 'string' ? term : (this.props.formatString && term.foundByID?this.props.formatString(term):term.term) )
   render () {
     const {
       otherTextInputProps,


### PR DESCRIPTION
I've added functionality for passing objects in as terms (in the shape `{term: string, searchableID?: string, ...}`) so the suggestions can be used to return objects, and also allow search-ability by a hidden ID. I've also added a prop to `AutoSuggest` called `formatString` to allow for items found using the `searchableID` to be displayed differently to signify how it was found.

It's something I've added for my own use, but think it's a useful thing for everyone.

Whether or not you perceive this to be within the scope of the project (or complete enough to be included), thanks for looking.