### PR TITLE
Removing proptype dependency on React

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
   "bugs": {
     "url": "https://github.com/silesky/react-native-autosuggest/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  },
   "description": "an autosuggest text input implementation for react native.",
   "devDependencies": {},
   "gitHead": "0c364d5e0561d3c83f1f4dbe967e7288d23923e3",

--- a/src/AutoSuggest.js
+++ b/src/AutoSuggest.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import {
   Animated,
   StyleSheet,


### PR DESCRIPTION
PropType on React is deprecated. Removing in favor of prop-types